### PR TITLE
Add 'preserveConstEnums: true' to tsconfig.

### DIFF
--- a/Box2D/Box2D/tsconfig.json
+++ b/Box2D/Box2D/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "es6",
     "module": "system",
+    "preserveConstEnums": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,


### PR DESCRIPTION
`preserveConstEnums: true` is very useful.
if no it , the output js file will exclude `enum` , it will be hard to use.

example: 
if no `enum` , users can't use `body.type = box2d.b2BodyType.b2_dynamicBody;`   , they have to use `body.type = 2`;