### PR TITLE
preserveConstEnums is useful when use js file in browser

### DIFF
--- a/Box2D/Box2D/tsconfig.json
+++ b/Box2D/Box2D/tsconfig.json
@@ -4,7 +4,8 @@
     "module": "system",
     "strict": true,
     "strictNullChecks": false,
-    "inlineSourceMap": true
+    "inlineSourceMap": true,
+    "preserveConstEnums": true
   },
   "include": [
     "**/*.ts"


### PR DESCRIPTION
I've add it  in  https://github.com/flyover/box2d.ts/pull/8 
But why be removed ?